### PR TITLE
Add PySide6 Modpack Designer GUI

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,16 @@
+import sys
+from PySide6 import QtWidgets
+from ui.main_window import MainWindow
+
+
+def main():
+    app = QtWidgets.QApplication(sys.argv)
+    with open("resources/dark_theme.qss") as f:
+        app.setStyleSheet(f.read())
+    window = MainWindow()
+    window.show()
+    sys.exit(app.exec())
+
+
+if __name__ == "__main__":
+    main()

--- a/models.py
+++ b/models.py
@@ -1,0 +1,46 @@
+from dataclasses import dataclass, field
+from typing import List, Dict
+
+
+@dataclass
+class Mod:
+    slug: str
+    title: str
+    description: str
+    author: str
+    version: str
+    url: str
+    x: float = 0
+    y: float = 0
+
+
+@dataclass
+class Category:
+    name: str
+    mods: List[Mod] = field(default_factory=list)
+    x: float = 0
+    y: float = 0
+    width: float = 200
+    height: float = 150
+
+    def to_dict(self) -> Dict:
+        return {
+            "name": self.name,
+            "mods": [mod.__dict__ for mod in self.mods],
+            "x": self.x,
+            "y": self.y,
+            "width": self.width,
+            "height": self.height,
+        }
+
+    @staticmethod
+    def from_dict(data: Dict) -> "Category":
+        cat = Category(
+            name=data["name"],
+            x=data.get("x", 0),
+            y=data.get("y", 0),
+            width=data.get("width", 200),
+            height=data.get("height", 150),
+        )
+        cat.mods = [Mod(**mod) for mod in data.get("mods", [])]
+        return cat

--- a/modrinth_api.py
+++ b/modrinth_api.py
@@ -1,0 +1,23 @@
+import os
+import requests
+
+MODRINTH_TOKEN = os.environ.get("MODRINTH_TOKEN", "mrp_0nUiSOTSQ7Xar35PfRapMOIwXH5CA4QaV3BMOSGlwmsAaxfjTgPWmyM6CQFg")
+BASE_URL = "https://api.modrinth.com/v2"
+
+
+class ModrinthAPI:
+    def __init__(self, token: str | None = None):
+        self.token = token or MODRINTH_TOKEN
+        self.session = requests.Session()
+        if self.token:
+            self.session.headers.update({"Authorization": self.token})
+
+    def search_mods(self, query: str, limit: int = 20):
+        if not query:
+            return []
+        url = f"{BASE_URL}/search"
+        params = {"query": query, "limit": limit}
+        r = self.session.get(url, params=params)
+        r.raise_for_status()
+        data = r.json()
+        return data.get("hits", [])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+PySide6
+requests
+jsonschema

--- a/resources/dark_theme.qss
+++ b/resources/dark_theme.qss
@@ -1,0 +1,24 @@
+/* Simple dark theme */
+QWidget {
+    background-color: #121212;
+    color: #f0f0f0;
+}
+
+QLineEdit, QListWidget, QGraphicsView {
+    background-color: #1e1e1e;
+    border: 1px solid #333;
+}
+
+QPushButton {
+    background-color: #333;
+    border: 1px solid #555;
+    padding: 5px;
+}
+
+QPushButton:hover {
+    background-color: #444;
+}
+
+QListWidget::item:selected {
+    background-color: #555;
+}

--- a/storage.py
+++ b/storage.py
@@ -1,0 +1,15 @@
+import json
+from typing import List
+from models import Category
+
+
+def save_schema(categories: List[Category], path: str):
+    data = [cat.to_dict() for cat in categories]
+    with open(path, 'w', encoding='utf-8') as f:
+        json.dump(data, f, indent=2)
+
+
+def load_schema(path: str) -> List[Category]:
+    with open(path, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+    return [Category.from_dict(cat) for cat in data]

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -1,0 +1,1 @@
+# ui package

--- a/ui/board.py
+++ b/ui/board.py
@@ -1,0 +1,118 @@
+from PySide6 import QtCore, QtGui, QtWidgets
+from models import Mod, Category
+
+
+class NodeItem(QtWidgets.QGraphicsRectItem):
+    def __init__(self, mod: Mod, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.mod = mod
+        self.setRect(0, 0, 120, 40)
+        self.setFlag(QtWidgets.QGraphicsItem.ItemIsMovable, True)
+        self.setFlag(QtWidgets.QGraphicsItem.ItemIsSelectable, True)
+        self.text = QtWidgets.QGraphicsTextItem(mod.title, self)
+        self.text.setPos(5, 5)
+
+    def to_model(self) -> Mod:
+        self.mod.x = self.scenePos().x()
+        self.mod.y = self.scenePos().y()
+        return self.mod
+
+
+class CategoryItem(QtWidgets.QGraphicsRectItem):
+    def __init__(self, category: Category, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.category = category
+        self.setRect(0, 0, category.width, category.height)
+        self.setBrush(QtGui.QColor(60, 60, 60, 100))
+        self.setFlag(QtWidgets.QGraphicsItem.ItemIsMovable, True)
+        self.setFlag(QtWidgets.QGraphicsItem.ItemIsSelectable, True)
+        self.text = QtWidgets.QGraphicsTextItem(category.name, self)
+        self.text.setDefaultTextColor(QtGui.QColor("white"))
+        self.text.setPos(5, 5)
+
+    def to_model(self) -> Category:
+        self.category.x = self.scenePos().x()
+        self.category.y = self.scenePos().y()
+        self.category.width = self.rect().width()
+        self.category.height = self.rect().height()
+        # collect mods inside
+        self.category.mods = []
+        for item in self.childItems():
+            if isinstance(item, NodeItem):
+                self.category.mods.append(item.to_model())
+        return self.category
+
+
+class BoardScene(QtWidgets.QGraphicsScene):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.setBackgroundBrush(QtGui.QColor("#1e1e1e"))
+
+    def dragEnterEvent(self, event: QtGui.QDragEnterEvent):
+        if event.mimeData().hasFormat("application/x-mod"):
+            event.acceptProposedAction()
+        else:
+            super().dragEnterEvent(event)
+
+    def dragMoveEvent(self, event: QtGui.QDragMoveEvent):
+        if event.mimeData().hasFormat("application/x-mod"):
+            event.acceptProposedAction()
+        else:
+            super().dragMoveEvent(event)
+
+    def dropEvent(self, event: QtGui.QDropEvent):
+        if event.mimeData().hasFormat("application/x-mod"):
+            data = event.mimeData().data("application/x-mod").data().decode()
+            mod_dict = eval(data)  # simple; assume safe
+            mod = Mod(
+                slug=mod_dict.get("slug", ""),
+                title=mod_dict.get("title", ""),
+                description=mod_dict.get("description", ""),
+                author=mod_dict.get("author", ""),
+                version=mod_dict.get("versions", ["unknown"])[0],
+                url=f"https://modrinth.com/mod/{mod_dict.get('slug')}"
+            )
+            pos = event.scenePos()
+            item = NodeItem(mod)
+            item.setPos(pos)
+            self.addItem(item)
+            event.acceptProposedAction()
+        else:
+            super().dropEvent(event)
+
+
+class BoardView(QtWidgets.QGraphicsView):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setScene(BoardScene(self))
+        self.setRenderHints(QtGui.QPainter.Antialiasing)
+        self.setAcceptDrops(True)
+        self.setDragMode(QtWidgets.QGraphicsView.RubberBandDrag)
+
+    def add_category(self, name="Category"):
+        cat = Category(name=name)
+        item = CategoryItem(cat)
+        item.setPos(0, 0)
+        self.scene().addItem(item)
+        return item
+
+    def to_models(self):
+        categories = []
+        for item in self.scene().items():
+            if isinstance(item, CategoryItem):
+                categories.append(item.to_model())
+        return categories
+
+    def load_from_models(self, categories):
+        self.scene().clear()
+        for cat in categories:
+            cat_item = CategoryItem(cat)
+            cat_item.setPos(cat.x, cat.y)
+            self.scene().addItem(cat_item)
+
+            for mod in cat.mods:
+                node = NodeItem(mod)
+                node.setParentItem(cat_item)
+                node.setPos(mod.x, mod.y)
+
+

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -1,0 +1,49 @@
+from PySide6 import QtCore, QtWidgets
+from .search_panel import SearchPanel
+from .board import BoardView
+from storage import save_schema, load_schema
+
+
+class MainWindow(QtWidgets.QMainWindow):
+    def __init__(self):
+        super().__init__()
+        self.setWindowTitle("Modpack Designer")
+        self.resize(1200, 800)
+
+        self.board = BoardView()
+        self.search_panel = SearchPanel()
+
+        central = QtWidgets.QSplitter()
+        central.addWidget(self.search_panel)
+        central.addWidget(self.board)
+        central.setStretchFactor(1, 1)
+        self.setCentralWidget(central)
+
+        toolbar = self.addToolBar("Main")
+        add_cat = QtWidgets.QAction("Add Category", self)
+        save_act = QtWidgets.QAction("Save", self)
+        load_act = QtWidgets.QAction("Load", self)
+        toolbar.addAction(add_cat)
+        toolbar.addAction(save_act)
+        toolbar.addAction(load_act)
+
+        add_cat.triggered.connect(self.add_category)
+        save_act.triggered.connect(self.save)
+        load_act.triggered.connect(self.load)
+
+    def add_category(self):
+        name, ok = QtWidgets.QInputDialog.getText(self, "Category name", "Name:")
+        if ok and name:
+            self.board.add_category(name)
+
+    def save(self):
+        path, _ = QtWidgets.QFileDialog.getSaveFileName(self, "Save", filter="JSON Files (*.json)")
+        if path:
+            save_schema(self.board.to_models(), path)
+
+    def load(self):
+        path, _ = QtWidgets.QFileDialog.getOpenFileName(self, "Load", filter="JSON Files (*.json)")
+        if path:
+            cats = load_schema(path)
+            self.board.load_from_models(cats)
+

--- a/ui/search_panel.py
+++ b/ui/search_panel.py
@@ -1,0 +1,44 @@
+from PySide6 import QtCore, QtGui, QtWidgets
+from modrinth_api import ModrinthAPI
+
+
+class ModListWidget(QtWidgets.QListWidget):
+    def startDrag(self, supportedActions):
+        item = self.currentItem()
+        if not item:
+            return
+        mod = item.data(QtCore.Qt.UserRole)
+        mime = QtCore.QMimeData()
+        mime.setData("application/x-mod", QtCore.QByteArray(str(mod).encode()))
+        drag = QtGui.QDrag(self)
+        drag.setMimeData(mime)
+        drag.exec(QtCore.Qt.CopyAction)
+
+
+class SearchPanel(QtWidgets.QWidget):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.api = ModrinthAPI()
+        self.search_edit = QtWidgets.QLineEdit()
+        self.search_button = QtWidgets.QPushButton("Search")
+        self.results_list = ModListWidget()
+        self.results_list.setSelectionMode(QtWidgets.QAbstractItemView.SingleSelection)
+        self.results_list.setDragEnabled(True)
+
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.addWidget(self.search_edit)
+        layout.addWidget(self.search_button)
+        layout.addWidget(self.results_list)
+
+        self.search_button.clicked.connect(self.on_search)
+
+    def on_search(self):
+        query = self.search_edit.text().strip()
+        self.results_list.clear()
+        if not query:
+            return
+        for mod in self.api.search_mods(query):
+            item = QtWidgets.QListWidgetItem(mod.get("title", "no title"))
+            item.setToolTip(mod.get("description", ""))
+            item.setData(QtCore.Qt.UserRole, mod)
+            self.results_list.addItem(item)


### PR DESCRIPTION
## Summary
- implement Modrinth API helper for searching mods
- define `Mod` and `Category` models and JSON storage helpers
- create `BoardView` graphics scene and `SearchPanel` for querying mods
- build a dark-themed GUI in `MainWindow`
- provide a stylesheet and requirements
- add entry point `main.py`

## Testing
- `python -m pip install -r requirements.txt`
- `python -m py_compile $(find . -name '*.py')`
- `QT_QPA_PLATFORM=offscreen python main.py` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_6843f6eaa050832ba3463b642606cb73