### PR TITLE
Fix QAction duplication in main_window

### DIFF
--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -26,10 +26,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
         add_cat = QAction("Add Category", self)
         save_act = QAction("Save", self)
-
-        add_cat = QtWidgets.QAction("Add Category", self)
-        save_act = QtWidgets.QAction("Save", self)
-        load_act = QtWidgets.QAction("Load", self)
+        load_act = QAction("Load", self)
 
         toolbar.addAction(add_cat)
         toolbar.addAction(save_act)


### PR DESCRIPTION
## Summary
- remove duplicate QAction creation and use consistent import

## Testing
- `python -m py_compile $(find . -name '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684402021694832b8506266098f98459